### PR TITLE
Fix typo for cancelling credential-dialog status

### DIFF
--- a/Examples/Dialog/src/app/default/credential-dialog/credential-dialog.component.ts
+++ b/Examples/Dialog/src/app/default/credential-dialog/credential-dialog.component.ts
@@ -123,7 +123,7 @@ export class CredentialDialogComponent extends BaseDialogComponent<CredentialDia
         this.hide({
           uid: '',
           password: '',
-          result: 'canceled'
+          result: 'cancelled'
         });
       }
     });


### PR DESCRIPTION
Catching DialogService.response.result in a cancelled state should be `result: 'cancelled`, not `result: 'canceled'`.